### PR TITLE
Use single-site wording for consistency, instead of workspace preview system

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,8 +144,8 @@
 				<div class="col-md-6">
 					<h4>Cross-site content staging</h4>
 					<p>Use Deploy with RELAXed Web services to stage content between different Drupal sites.</p>
-                    <h4>Workspace preview system</h4>
-					<p>The Workspace module works with Deploy to provide single site content staging.</p>
+                    <h4>Single-site content staging</h4>
+					<p>The Workspace module works with Deploy to provide a workspace preview system for single-site content staging.</p>
                     <h4>Fully decoupled site</h4>
 					<p>The API provided by RELAXed Web Services is a great way to create a decoupled Drupal site.</p>
 				</div>


### PR DESCRIPTION
We use the phrase "cross-site" content  staging. So let's also use "single-site" content staging for the other use case.